### PR TITLE
Initializes self.delegate with an empty NSMutableSet, as opposed to an N...

### DIFF
--- a/GVMusicPlayerController/GVMusicPlayerController.m
+++ b/GVMusicPlayerController/GVMusicPlayerController.m
@@ -85,7 +85,7 @@ void audioRouteChangeListenerCallback (void *inUserData, AudioSessionPropertyID 
     self = [super init];
     if (self) {
         self.indexOfNowPlayingItem = NSNotFound;
-        self.delegates = [NSMutableArray array];
+        self.delegates = [NSMutableSet set];
 
         // Set defaults
         self.updateNowPlayingCenter = YES;


### PR DESCRIPTION
...SMutableArray. This silences warnings that self.delegates should be an NSMutableSet. Also, order is irrelevant, so an NSSet is more appropriate. 
