### PR TITLE
Exposed public methods for setting the current playing item and exposed ...

### DIFF
--- a/GVMusicPlayerController/GVMusicPlayerController.h
+++ b/GVMusicPlayerController/GVMusicPlayerController.h
@@ -29,6 +29,8 @@
 @property (nonatomic) float volume; // 0.0 to 1.0
 @property (nonatomic, readonly) NSUInteger indexOfNowPlayingItem; // NSNotFound if no queue
 @property (nonatomic) BOOL updateNowPlayingCenter; // default YES
+@property (nonatomic, readonly) NSArray *queue;
+@property (nonatomic) BOOL shouldReturnToBeginningWhenSkippingToPreviousItem;
 
 + (GVMusicPlayerController *)sharedInstance;
 
@@ -41,6 +43,9 @@
 - (void)skipToNextItem;
 - (void)skipToBeginning;
 - (void)skipToPreviousItem;
+
+- (void) playItemAtIndex:(NSUInteger)index;
+- (void) playItem:(MPMediaItem*)item;
 
 // Check MPMediaPlayback for other playback related methods
 // and properties like play, plause, currentPlaybackTime

--- a/GVMusicPlayerController/GVMusicPlayerController.m
+++ b/GVMusicPlayerController/GVMusicPlayerController.m
@@ -34,7 +34,7 @@
 @property (copy, nonatomic) NSArray *delegates;
 @property (strong, nonatomic) AVPlayer *player;
 @property (strong, nonatomic) NSArray *originalQueue;
-@property (strong, nonatomic) NSArray *queue;
+@property (strong, nonatomic, readwrite) NSArray *queue;
 @property (strong, nonatomic, readwrite) MPMediaItem *nowPlayingItem;
 @property (nonatomic, readwrite) NSUInteger indexOfNowPlayingItem;
 @property (nonatomic) BOOL interrupted;
@@ -91,6 +91,7 @@ void audioRouteChangeListenerCallback (void *inUserData, AudioSessionPropertyID 
         self.updateNowPlayingCenter = YES;
         self.repeatMode = MPMusicRepeatModeNone;
         self.shuffleMode = MPMusicShuffleModeOff;
+        self.shouldReturnToBeginningWhenSkippingToPreviousItem = YES;
 
         // Make sure the system follows our playback status
         AVAudioSession *audioSession = [AVAudioSession sharedInstance];
@@ -197,7 +198,8 @@ void audioRouteChangeListenerCallback (void *inUserData, AudioSessionPropertyID 
 - (void)skipToPreviousItem {
     if (self.indexOfNowPlayingItem > 0) {
         self.indexOfNowPlayingItem--;
-    } else {
+    }
+    else if (self.shouldReturnToBeginningWhenSkippingToPreviousItem) {
         [self skipToBeginning];
     }
 }
@@ -352,6 +354,15 @@ void audioRouteChangeListenerCallback (void *inUserData, AudioSessionPropertyID 
     [self doUpdateNowPlayingCenter];
 
     self.isLoadingAsset = NO;
+}
+
+- (void) playItemAtIndex:(NSUInteger)index {
+    [self setIndexOfNowPlayingItem:index];
+}
+
+- (void) playItem:(MPMediaItem*)item {
+    NSUInteger indexOfItem = [self.queue indexOfObject:item];
+    [self playItemAtIndex:indexOfItem];
 }
 
 - (void)handleAVPlayerItemDidPlayToEndTimeNotification {


### PR DESCRIPTION
...the queue (readonly) for anyone using the library to be able to get a better look at what's in there.

Basically I didn't change any of the methods except by adding new things.
- Exposed the queue, readonly.
- Added `playItemAtIndex:` and `playItem:`
- Added a boolean property (set to YES by default) to allow people to choose whether or not skipping backwards defaults to skipping to the beginning of the track.
