### PR TITLE
Changed deprecated ipodMusicPlayer to systemMusicPlayer

### DIFF
--- a/GVMusicPlayerController/GVMusicPlayerController.m
+++ b/GVMusicPlayerController/GVMusicPlayerController.m
@@ -108,21 +108,21 @@ void audioRouteChangeListenerCallback (void *inUserData, AudioSessionPropertyID 
         AudioSessionAddPropertyListener (kAudioSessionProperty_AudioRouteChange, audioRouteChangeListenerCallback, (__bridge void*)self);
 
         // Listen for volume changes
-        [[MPMusicPlayerController iPodMusicPlayer] beginGeneratingPlaybackNotifications];
+        [[MPMusicPlayerController systemMusicPlayer] beginGeneratingPlaybackNotifications];
         [[NSNotificationCenter defaultCenter] addObserver:self
                                                  selector:@selector(handle_VolumeChanged:)
                                                      name:MPMusicPlayerControllerVolumeDidChangeNotification
-                                                   object:[MPMusicPlayerController iPodMusicPlayer]];
+                                                   object:[MPMusicPlayerController systemMusicPlayer]];
     }
 
     return self;
 }
 
 - (void)dealloc {
-    [[MPMusicPlayerController iPodMusicPlayer] endGeneratingPlaybackNotifications];
+    [[MPMusicPlayerController systemMusicPlayer] endGeneratingPlaybackNotifications];
     [[NSNotificationCenter defaultCenter] removeObserver:self
                                   name:MPMusicPlayerControllerVolumeDidChangeNotification
-                                object:[MPMusicPlayerController iPodMusicPlayer]];
+                                object:[MPMusicPlayerController systemMusicPlayer]];
 }
 
 - (void)addDelegate:(id<GVMusicPlayerControllerDelegate>)delegate {
@@ -263,11 +263,11 @@ void audioRouteChangeListenerCallback (void *inUserData, AudioSessionPropertyID 
 }
 
 - (float)volume {
-    return [MPMusicPlayerController iPodMusicPlayer].volume;
+    return [MPMusicPlayerController systemMusicPlayer].volume;
 }
 
 - (void)setVolume:(float)volume {
-    [MPMusicPlayerController iPodMusicPlayer].volume = volume;
+    [MPMusicPlayerController systemMusicPlayer].volume = volume;
     for (id <GVMusicPlayerControllerDelegate> delegate in self.delegates) {
         if ([delegate respondsToSelector:@selector(musicPlayer:volumeChanged:)]) {
             [delegate musicPlayer:self volumeChanged:volume];
@@ -418,7 +418,7 @@ void audioRouteChangeListenerCallback (void *inUserData, AudioSessionPropertyID 
 - (void)handle_VolumeChanged:(NSNotification *)notification {
     for (id <GVMusicPlayerControllerDelegate> delegate in self.delegates) {
         if ([delegate respondsToSelector:@selector(musicPlayer:volumeChanged:)]) {
-            [delegate musicPlayer:self volumeChanged:[MPMusicPlayerController iPodMusicPlayer].volume];
+            [delegate musicPlayer:self volumeChanged:[MPMusicPlayerController systemMusicPlayer].volume];
         }
     }
 }


### PR DESCRIPTION
Great controller but you're using ipodMusicPlayer which has been deprecated as of iOS 8 and now we're supposed to use systemMusicPlayer.  So I replaced all references to it in your GCMusicPlayerController.m file.  Thanks!

https://developer.apple.com/library/prerelease/ios/documentation/MediaPlayer/Reference/MPMusicPlayerController_ClassReference/index.html


P.S., I'm trying to create a simple music player app and hoping yours solves all my issues with the MPMedia player api.