### PR TITLE
Quick iOS 11 compatibility fix

### DIFF
--- a/Example/ViewController.m
+++ b/Example/ViewController.m
@@ -79,10 +79,6 @@
     return YES;
 }
 
-- (void)remoteControlReceivedWithEvent:(UIEvent *)receivedEvent {
-    [[GVMusicPlayerController sharedInstance] remoteControlReceivedWithEvent:receivedEvent];
-}
-
 #pragma mark - IBActions
 
 - (IBAction)playButtonPressed {

--- a/GVMusicPlayerController/GVMusicPlayerController.h
+++ b/GVMusicPlayerController/GVMusicPlayerController.h
@@ -36,7 +36,6 @@
 
 - (void)addDelegate:(id<GVMusicPlayerControllerDelegate>)delegate;
 - (void)removeDelegate:(id<GVMusicPlayerControllerDelegate>)delegate;
-- (void)remoteControlReceivedWithEvent:(UIEvent *)receivedEvent;
 - (void)setQueueWithItemCollection:(MPMediaItemCollection *)itemCollection;
 - (void)setQueueWithQuery:(MPMediaQuery *)query;
 


### PR DESCRIPTION
Drop remote `UIEvents` in favour of `MPRemoteCommandCenter`

– this move fixes compatibility with iOS 11 – mainly allows the Command Centre and Lock Screen audio widgets to work with the implementing app properly again
– `MPRemoteCommandCenter` is available since iOS 7.1